### PR TITLE
Remove incorrect dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,5 @@
         "Datatables",
         "jQuery",
         "table"
-    ],
-    "require": {
-        "components/jquery": ">=1.7"
-    }
+    ]
 }


### PR DESCRIPTION
Somehow `components/jquery` got included as a dependency for Composer, causing all other packages to include that deprecated/archived repo with the install. As far as I can tell this repo is supposed to be the root requirement and should not have other dependencies.