### PR TITLE
Updated Layout type to allow null value

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -182,7 +182,7 @@ type LayoutEdge = 'Start' | 'End';
 
 type LayoutKeys = `${LayoutSide}${LayoutNumber}${LayoutEdge}` | `${LayoutSide}${LayoutNumber}`;
 
-type Layout = Partial<Record<LayoutKeys, keyof Feature | Feature | Array<keyof Feature> | Feature[]>>;
+type Layout = Partial<Record<LayoutKeys, keyof Feature | Feature | Array<keyof Feature> | Feature[] | null>>;
 
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -68,7 +68,7 @@ export type CellIdxWithVisible = {
 }
 
 export type SearchInput<T> = string | RegExp | ((data: string, rowData: T) => boolean);
-export type SearchInputColumn<T> = string | RegExp | ((data: string, rowData: T, column: number) => boolean);
+export type SearchInputColumn<T> = string | RegExp | ((data: string, rowData: T, rowIndex: number, columnIndex: number) => boolean);
 
 export type HeaderStructure = {
     cell: HTMLElement;


### PR DESCRIPTION
Current implementation only allows value or undefined.  In order to remove the default layout a null value must be used, which setting a layout field to undefined does not do.